### PR TITLE
Server Interface init() implementation, global object declaration

### DIFF
--- a/server/js/main.js
+++ b/server/js/main.js
@@ -3,11 +3,6 @@ var Metrics = require('./metrics');
 var ProductionConfig = require('./productionconfig');
 var _ = require('underscore');
 
-// load and initialize Erdstall interface server sited
-var erdstallServerInterface = require("../../ts/erdstallserverinterface").default;
-var erdstallServer = new erdstallServerInterface();
-erdstallServer.init();
-
 function main(config) {
     var Log = require('log');
     switch(config.debug_level) {
@@ -23,6 +18,10 @@ function main(config) {
     if(production_config.inProduction()) {
         _.extend(config, production_config.getProductionSettings());
     }
+
+    // Load and initialize Erdstall server interface
+    var erdstallServer = require("../../ts/erdstallserverinterface").erdstallServer;
+    erdstallServer.init();
 
     var ws = require("./ws");
     var WorldServer = require("./worldserver");

--- a/ts/erdstallserverinterface.ts
+++ b/ts/erdstallserverinterface.ts
@@ -1,9 +1,10 @@
 import { Address } from "@polycrypt/erdstall/ledger";
 import { Assets, Tokens } from "@polycrypt/erdstall/ledger/assets";
-import { Session } from "@polycrypt/erdstall/session";
+import { Session } from "@polycrypt/erdstall";
 import NFT from "./nft";
-import erdstallClientInterface from "./erdstallclientinterface"
+import erdstallClientInterface, { NetworkID } from "./erdstallclientinterface"
 import { TxReceipt } from "@polycrypt/erdstall/api/responses";
+import { ethers } from "ethers";
 
 export default class erdstallServerInterface extends erdstallClientInterface {
 	
@@ -12,8 +13,34 @@ export default class erdstallServerInterface extends erdstallClientInterface {
 		networkID: number = 1337,
 		erdOperatorUrl: URL = new URL("ws://127.0.0.1:8401/ws")
 	): Promise<{account : String}> {
-		console.log("Initialized new session");
-		return {account: "abcdefg"};
+		const ethRpcUrl = "ws://127.0.0.1:8545/";
+		const provider = new ethers.providers.JsonRpcProvider(ethRpcUrl);
+		if(provider == null) {
+			throw new Error("Unable to get Account Provider for Ethereum URL: " + ethRpcUrl);
+		}
+
+		const mnemonic = "pistol kiwi shrug future ozone ostrich match remove crucial oblige cream critic";
+		const derivationPath = `m/44'/60'/0'/0/2`;
+		const user = ethers.Wallet.fromMnemonic(mnemonic, derivationPath);
+
+		var session;
+		try {
+			session = new Session(Address.fromString(user.address), user.connect(provider), erdOperatorUrl);
+			await session.initialize();
+			await session.subscribeSelf();
+			await session.onboard();
+		} catch (error) {
+			if(error) {
+				throw new Error("Error initializing server session" + error);
+			}
+			else {
+				throw new Error("Error initializing server session");
+			}
+		}
+
+		this._session = session;
+		console.log("Initialized new server session: " + user.address);
+		return {account: user.address};
 	}
 
 	// Mints a new NFT and returns TxReceipt promise
@@ -64,6 +91,8 @@ export default class erdstallServerInterface extends erdstallClientInterface {
 		}
 	}
 }
+
+export var erdstallServer = new erdstallServerInterface();
 
 // Converts NFT object to Assets object
 function getAssetsFromNFT(nft: NFT): Assets {

--- a/ts/erdstallserverinterface.ts
+++ b/ts/erdstallserverinterface.ts
@@ -13,6 +13,7 @@ export default class erdstallServerInterface extends erdstallClientInterface {
 		networkID: number = 1337,
 		erdOperatorUrl: URL = new URL("ws://127.0.0.1:8401/ws")
 	): Promise<{account : String}> {
+		// TODO: Load parameters from config
 		const ethRpcUrl = "ws://127.0.0.1:8545/";
 		const provider = new ethers.providers.JsonRpcProvider(ethRpcUrl);
 		if(provider == null) {
@@ -45,24 +46,27 @@ export default class erdstallServerInterface extends erdstallClientInterface {
 
 	// Mints a new NFT and returns TxReceipt promise
 	async mintNFT(
-		address: Address,
 		id: bigint = BigInt(Math.round(Math.random() * Number.MAX_SAFE_INTEGER))
 	): Promise<{txReceipt: TxReceipt}> {
 		if(!this._session) {
 			throw new Error("Server session uninitialized");
 		}
-		return{txReceipt: await this._session.mint( address, id )};
+		// TODO: Put NFT in database
+		var txReceipt = await this._session.mint(this._session.address, id);
+		console.log("Minted NFT with ID: " + id);
+		return{txReceipt};
 	}
 
 	// Burns NFT and returns TxReceipt promise
 	async burnNFT(
 		nft: NFT
 	): Promise<{txReceipt: TxReceipt}> {
+		// TODO: Remove NFT from database
 		if(!this._session) {
 			throw new Error("Server session uninitialized");
 		}
 		try {
-			return{txReceipt:await this._session.burn(getAssetsFromNFT(nft))};
+			return{txReceipt: await this._session.burn(getAssetsFromNFT(nft))};
 		} catch (error) {
 			if(error) {
 				throw new Error("Server unable to burn NFT" + error);


### PR DESCRIPTION
Implemented server interface init() method, global server object is now declared in erdstallserverinterface.ts and can be accessed wherever in /server/** files like (e.g. in server/js/main.js): 

var erdstallServer = require("../../ts/erdstallserverinterface").erdstallServer;